### PR TITLE
Updated _config.yml to fix highlighter error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ github_username:  github_username
 # Build settings
 markdown: kramdown
 
-highlighter: pygments
+highlighter: rouge
 
 # Pagination
 paginate: 15


### PR DESCRIPTION
Github Pages build warning...

The page build completed successfully, but returned the following warning:

You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.